### PR TITLE
OPS-12702 Direct config to new hostname

### DIFF
--- a/src/config.es6
+++ b/src/config.es6
@@ -1,5 +1,5 @@
 const CONFIG = {
-    crossbar_uri: 'ws://157.230.143.136:8080/ws',
+    crossbar_uri: 'ws://crossbar-estimator.fandom-dev.us/ws',
     realm: 'realm1'
 };
 


### PR DESCRIPTION
The old IP hardcoded here is a dead digital ocean bucket.  The new hostname isn't accepting traffic, but we'll get to that next